### PR TITLE
add opening  api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `entity_opening_geometry`.
+* Added `entity_body_with_opening_geometry`.
+* Added `opening` attribute to `Product`.
+* Added `body_with_opening` attribute to `Product`.
+
 ### Changed
 
-### Removed
+* `entity_body_geometry` no longer includes openings.
 
+### Removed
 
 ## [0.2.0] 2023-03-21
 
@@ -21,4 +27,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Removed
-

--- a/scripts/3.1_model_view.py
+++ b/scripts/3.1_model_view.py
@@ -17,6 +17,6 @@ viewer = App(enable_sceneform=True)
 
 for entity in model.get_entities_by_type("IfcBuildingElement"):
     print("Converting to brep:", entity)
-    obj = viewer.add(Collection(entity.body), name=entity.name)
+    obj = viewer.add(Collection(entity.body_with_opening), name=entity.name)
 
 viewer.run()

--- a/scripts/3.3_opening.py
+++ b/scripts/3.3_opening.py
@@ -1,0 +1,28 @@
+import os
+
+from compas_view2.app import App
+from compas_view2.collections import Collection
+
+from compas_ifc.model import Model
+
+HERE = os.path.dirname(__file__)
+FILE = os.path.join(
+    HERE,
+    "..",
+    "data",
+    "wall-with-opening-and-window.ifc",
+)
+
+
+model = Model(FILE)
+viewer = App(enable_sceneform=True)
+
+for entity in model.get_entities_by_type("IfcWall"):
+    print("Converting brep:", entity)
+    viewer.add(Collection(entity.body), name="body", opacity=0.5, facecolor=(0, 1, 0))
+    viewer.add(Collection(entity.opening), name="opening", facecolor=(1, 0, 0))
+    obj = viewer.add(Collection(entity.body_with_opening), name="combined", show_faces=True)
+    obj.translation = [0, 2, 0]
+
+viewer.view.camera.zoom_extents()
+viewer.run()

--- a/src/compas_ifc/entities/product.py
+++ b/src/compas_ifc/entities/product.py
@@ -25,6 +25,8 @@ class Product(ObjectDefinition):
         self._axis = None
         self._box = None
         self._body = None
+        self._opening = None
+        self._body_with_opening = None
 
     def classifications(self) -> List[Dict[str, str]]:
         """
@@ -121,3 +123,27 @@ class Product(ObjectDefinition):
     @body.setter
     def body(self, value):
         self._body = value
+
+    @property
+    def opening(self):
+        from compas_ifc.representation import entity_opening_geometry
+
+        if not self._opening:
+            self._opening = entity_opening_geometry(self)
+        return self._opening
+
+    @opening.setter
+    def opening(self, value):
+        self._opening = value
+
+    @property
+    def body_with_opening(self):
+        from compas_ifc.representation import entity_body_with_opening_geometry
+
+        if not self._body_with_opening:
+            self._body_with_opening = entity_body_with_opening_geometry(self, self.body, self.opening)
+        return self._body_with_opening
+
+    @body_with_opening.setter
+    def body_with_opening(self, value):
+        self._body_with_opening = value


### PR DESCRIPTION
- Separate opening geometry from `body`
- Add `opening` attribute
- Add `body_with_opening` attribute

See example: `scripts/3.3_opening.py`
```python
    viewer.add(Collection(entity.body), name="body", opacity=0.5, facecolor=(0, 1, 0))
    viewer.add(Collection(entity.opening), name="opening", facecolor=(1, 0, 0))
    obj = viewer.add(Collection(entity.body_with_opening), name="combined", show_faces=True)
    obj.translation = [0, 2, 0]
```



<img width="400" alt="image" src="https://user-images.githubusercontent.com/17893605/233599804-0e2579e5-1294-4511-a250-ca3ead215fbe.png">
